### PR TITLE
set the input parameter tab completion the same as the standard man command 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,3 +59,6 @@ uninstall:
   @rm -f $(DESTDIR)$(bindir)/manweb
   @echo -e '   'Deleting file $(green)manweb$(reset) in $(green)$(DESTDIR)$(bindir)/$(reset)$(bold)manweb$(reset)
   @echo -e $(green)Uninstalling DONE$(reset)
+
+update_completion:
+    @$(CURDIR)/autocomplete.sh 

--- a/autocomplete.sh
+++ b/autocomplete.sh
@@ -1,6 +1,6 @@
 
 
-echo -e -n "would you like to allow tab completion for manpdf and manweb commands?\n(this may require you to type you password to modify the /usr/share/bash-completion/completions/man file)\n[y/n]";
+echo -e -n "would you like to allow tab completion for manpdf and manweb?\n(this may require you to type your password to modify the /usr/share/bash-completion/completions/man file)\n[y/n]";
 read -r answer;
 if [ "$answer" == "${answer#[Yy]}" ]; then
     echo "No changes made";
@@ -10,7 +10,7 @@ fi
 if [ -f "/usr/share/bash-completion/completions/man" ]; then 
         if grep   '^\s*complete.*\bman\b' "/usr/share/bash-completion/completions/man" | grep -qv 'manpdf\|manweb'; then 
             sudo sed -i '/^\s*complete.*\bman\b/ s/$/ manpdf manweb/' "/usr/share/bash-completion/completions/man"; 
-            echo "Updated completion for man command"; 
+            echo "autocompletion for manpdf and manweb updated. You may need to restart your terminal for changes to take effect"; 
         else \
             echo "ERROR: No suitable line found in /usr/share/bash-completion/completions/man could not update"; 
         fi \

--- a/autocomplete.sh
+++ b/autocomplete.sh
@@ -1,0 +1,21 @@
+
+
+echo -e -n "would you like to allow tab completion for manpdf and manweb commands?\n(this may require you to type you password to modify the /usr/share/bash-completion/completions/man file)\n[y/n]";
+read -r answer;
+if [ "$answer" == "${answer#[Yy]}" ]; then
+    echo "No changes made";
+    exit 0;
+fi
+
+if [ -f "/usr/share/bash-completion/completions/man" ]; then 
+        if grep   '^\s*complete.*\bman\b' "/usr/share/bash-completion/completions/man" | grep -qv 'manpdf\|manweb'; then 
+            sudo sed -i '/^\s*complete.*\bman\b/ s/$/ manpdf manweb/' "/usr/share/bash-completion/completions/man"; 
+            echo "Updated completion for man command"; 
+        else \
+            echo "ERROR: No suitable line found in /usr/share/bash-completion/completions/man could not update"; 
+        fi \
+else \
+        echo "ERROR: /usr/share/bash-completion/completions/man not found could not update "; 
+fi
+
+


### PR DESCRIPTION
created new make target that calls autocomplete .sh this script writes to /usr/share/bash-completion/completions/man and adds the manpdf and manweb to the complete function which would give manpdf and manweb the same tab completion for program parameters as the regular man program